### PR TITLE
add QR redirect pages

### DIFF
--- a/qr/index.html
+++ b/qr/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Reedirektin...</title>
+  
+  <script type="text/javascript">
+    window.location.replace("https://www.stonkscoin.org");
+  </script>
+
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=https://www.stonkscoin.org">
+  </noscript>
+
+  <style>
+    html {
+      font-size: 16px;
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif;
+    }
+    body {
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
+    p {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+    a {
+      color: #0000FF;
+      text-decoration: underline;
+    }
+  </style>
+
+</head>
+<body>
+  <p>Reedirektin u... If no go, <a href="https://www.stonkscoin.org">klik dis</a>.
+  </p>
+</body>
+</html>

--- a/qr2/index.html
+++ b/qr2/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Reedirektin...</title>
+  
+  <script type="text/javascript">
+    window.location.replace("https://www.stonkscoin.org");
+  </script>
+
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=https://www.stonkscoin.org">
+  </noscript>
+
+  <style>
+    html {
+      font-size: 16px;
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif;
+    }
+    body {
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
+    p {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+    a {
+      color: #0000FF;
+      text-decoration: underline;
+    }
+  </style>
+
+</head>
+<body>
+  <p>Reedirektin u... If no go, <a href="https://www.stonkscoin.org">klik dis</a>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
Adds https://stonkscoin.org/qr and https://stonkscoin.org/qr2 for QR code redirects

The implementation allows the destination URLs to be adjusted. Currently both redirect to stonkscoin.org 

Leverages `window.replace` for a neater browser history